### PR TITLE
import version number from package.json

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -11,7 +11,6 @@
     data: function () {
       return {
         section: 'Head',
-        version: '0.6.5',
         callingAPI: false,
         serverURI: 'http://localhost:8080',
         caller: this.$http

--- a/src/components/Dash.vue
+++ b/src/components/Dash.vue
@@ -79,7 +79,7 @@
             <a href="https://github.com/Intevation/intelmq-fody">IntelMQ-Fody Source Code</a>
         </span>
         <div class="pull-right hidden-xs">
-            <strong>Version: {{ this.$parent.version }}</strong>
+            <strong>Version: {{ version }}</strong>
         </div>
     </footer>
   </div>
@@ -87,6 +87,7 @@
 </template>
 
 <script>
+import { version } from '../../package.json'
 require('hideseek')
 
 module.exports = {
@@ -115,6 +116,9 @@ module.exports = {
     },
     callAPI: function () {
       return this.$parent.callAPI
+    },
+    version: function () {
+      return version
     }
   },
   methods: {


### PR DESCRIPTION
Version number does not need to be defined in two places. Can be directly imported from package json (thanks to [webpack](https://webpack.js.org/loaders/json-loader/)).

> Since webpack >= v2.0.0, importing of JSON files will work by default.